### PR TITLE
Use bcryptjs instead of brcypt to avoid issues with compiling

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var bcrypt = require('bcrypt');
+var bcrypt = require("bcryptjs");
 var chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
 var charsLength = chars.length;
 
@@ -26,4 +26,4 @@ exports.hash = function(str, cb) {
   });
 };
 
-exports.compare = bcrypt.compare; 
+exports.compare = bcrypt.compare;

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "node": ">=0.8"
   },
   "dependencies": {
-    "bcrypt": "~0.7.5"
+    "bcryptjs": "~0.7.8"
   },
   "devDependencies": {
     "mocha": "*",

--- a/test/passify.js
+++ b/test/passify.js
@@ -24,10 +24,13 @@ describe('Passify', function() {
 
   describe('Compare', function() {
     it('should return false when comparing a password to a wrong hash.', function(cb) {
-      passify.compare('secret', '123', function(err, bool) {
-        bool.should.be.false;
-        cb();
-      });
+      passify.hash('secret', function(err, hash) {
+        passify.compare('different secret', hash, function(err, bool) {
+          bool.should.be.false;
+          cb();
+        });
+      })
+      
     });
     it('should return true when comparing a password to a correct hash.', function(cb) {
       passify.compare('secret', '$2a$05$uwnq6r5LxGIMjFGjHwKBWuMgcH/XcazHPG6b/xj3Yze5DRd6NmNGO', function(err, bool) {


### PR DESCRIPTION
bcryptjs is API compatible to bcrypt but 100% pure JS, which avoids issues with the node-gyp compiling, for example having the wrong python version and similar issues.

Basically, it is the same thing but just JS, so no issues caused by the native stuff, which makes for better forward and backwards compatibility and an easier time when deploying. Always bet on JS™ :)
